### PR TITLE
Add About section, faux theme file,  reset globals

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,0 @@
-body {
-  display: initial;
-  margin: initial;
-}
-
-#root {
-  font-family: "Ubuntu Condensed", sans-serif;
-  margin: initial;
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,11 @@
-import { css } from "@emotion/css";
-import "./App.css";
+import { About } from "./pages/About";
+import { Hero } from "./pages/Hero";
 
 function App() {
   return (
     <>
-      <div
-        className={css`
-          font-size: 10em;
-        `}
-      >
-        CF
-      </div>
-
-      <div
-        className={css`
-          font-size: 2em;
-        `}
-      >
-        Chris Flinchbaugh
-      </div>
-      <div>Software Engineer | Front-End Specialized | UI/UX Engineer</div>
+      <Hero />
+      <About />
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,24 @@
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  display: initial;
+  margin: initial;
+  color: #98004b;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+#root {
+  font-family: "Ubuntu Condensed", sans-serif;
+  margin: initial;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+::-webkit-scrollbar {
+  width: 12px;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+::-webkit-scrollbar-track-piece {
+  background-color: darkslategray;
+}
+
+::-webkit-scrollbar-thumb:vertical {
+  height: 30px;
+  background-color: gray;
+  border-radius: 5px;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/src/pages/About.test.tsx
+++ b/src/pages/About.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { About } from "./About";
+
+describe("About", () => {
+  it("renders tagline", () => {
+    render(<About />);
+    expect(screen.getByText("One")).toBeInTheDocument();
+    expect(screen.getByText("BOLD")).toBeInTheDocument();
+    expect(screen.getByText("Developer")).toBeInTheDocument();
+  });
+
+  it("renders specialize in people content", () => {
+    render(<About />);
+    expect(screen.getByText(/I specialize in/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Providing meaningful design feedback, shaping coding best-practices, and communicating between lines of business are all paths that lead me to the heart of development- creating an application that solves problems for real people./
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders solve problems content", () => {
+    render(<About />);
+    expect(screen.getByText(/I solve/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /I am passionate about finding the root problem, identifying process gaps, and ensuring consistency. I strive to analyze designs and code without preconceptions to ensure never missing the forest for the trees./
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,86 @@
+import { css } from "@emotion/css";
+import { theme } from "../theme";
+
+export const About = () => {
+  return (
+    <div
+      className={css`
+        display: flex;
+        gap: ${theme.spacing.md};
+        flex-direction: column;
+        justify-content: center;
+        height: 100vh;
+        background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+        padding: 0 ${theme.spacing.lg};
+      `}
+    >
+      <div
+        className={css`
+          text-align: center;
+        `}
+      >
+        <span
+          className={css`
+            font-size: ${theme.fontSizes.lg};
+          `}
+        >
+          One
+        </span>
+        <span
+          className={css`
+            font-size: 2rem;
+            padding: ${theme.spacing.sm};
+            ${theme.mq.md} {
+              font-size: 5rem;
+            }
+            ${theme.mq.md} {
+              font-size: 10rem;
+            }
+          `}
+        >
+          BOLD
+        </span>
+        <span>Developer</span>
+      </div>
+
+      <div
+        className={css`
+          display: flex;
+          gap: ${theme.spacing.lg};
+
+          flex-direction: column;
+          ${theme.mq.md} {
+            flex-direction: row;
+          }
+        `}
+      >
+        <div
+          className={css`
+            ${theme.mq.md} {
+              text-align: end;
+            }
+          `}
+        >
+          <strong>
+            I specialize in <i>people</i>.
+          </strong>
+          <br />
+          Providing meaningful design feedback, shaping coding best-practices,
+          and communicating between lines of business are all paths that lead me
+          to the heart of development- creating an application that solves
+          problems for real people.
+        </div>
+
+        <div>
+          <strong>
+            I solve <i>problems</i>.
+          </strong>
+          <br />I am passionate about finding the root problem, identifying
+          process gaps, and ensuring consistency. I strive to analyze designs
+          and code without preconceptions to ensure never missing the forest for
+          the trees.
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Hero.test.tsx
+++ b/src/pages/Hero.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { Hero } from "./Hero";
+
+describe("Hero", () => {
+  it("renders initials", () => {
+    render(<Hero />);
+    expect(screen.getByText("CF")).toBeInTheDocument();
+  });
+
+  it("renders name", () => {
+    render(<Hero />);
+    expect(screen.getByText("Chris Flinchbaugh")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(<Hero />);
+    expect(
+      screen.getByText(
+        "Software Engineer | Front-End Specialized | UI/UX Engineer"
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -1,0 +1,34 @@
+import { css } from "@emotion/css";
+import { theme } from "../theme";
+
+export const Hero = () => {
+  return (
+    <div
+      className={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        background: linear-gradient(to bottom, #ffffff 85%, #fe8a75 100%);
+      `}
+    >
+      {" "}
+      <div
+        className={css`
+          font-size: 10em;
+        `}
+      >
+        CF
+      </div>
+      <div
+        className={css`
+          font-size: ${theme.fontSizes.xxl};
+        `}
+      >
+        Chris Flinchbaugh
+      </div>
+      <div>Software Engineer | Front-End Specialized | UI/UX Engineer</div>
+    </div>
+  );
+};

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,25 @@
+const breakpoints = [576, 768, 992, 1200];
+
+export const theme = {
+  mq: {
+    sm: `@media (min-width: ${breakpoints[0]}px)`,
+    md: `@media (min-width: ${breakpoints[1]}px)`,
+    lg: `@media (min-width: ${breakpoints[2]}px)`,
+    xl: `@media (min-width: ${breakpoints[3]}px)`,
+  },
+  spacing: {
+    xs: "0.25rem", // 4px
+    sm: "0.5rem", // 8px
+    md: "1rem", // 16px
+    lg: "1.5rem", // 24px
+    xl: "2rem", // 32px
+  },
+  fontSizes: {
+    xs: "0.75rem", // 12px
+    sm: "0.875rem", // 14px
+    md: "1rem", // 16px
+    lg: "1.25rem", // 20px
+    xl: "1.5rem", // 24px
+    xxl: "2rem", // 32px
+  },
+};

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts"],"version":"5.6.3"}
+{"root":["./src/app.test.tsx","./src/app.tsx","./src/main.tsx","./src/setuptests.ts","./src/vite-env.d.ts"],"version":"5.6.3"}


### PR DESCRIPTION
Why
--
- As a user viewing the portfolio, I should see an About section describing the engineer
- As a developer working in the codebase, I should have basic standardized sizes to pull from (via faux-theme file)

How
--
- Migrate `App.css` content into `index.css`, replacing previously init-ed content
- Abstract `App` content into separate `Hero` component, add `About`

Notes
--
- Some auto-formatting occurred
- I'm using the platform agnostic implementation of Emotion which doesn't support the ThemeProvider (at least not with the current configuration); I may revisit this in the future but the implementation I have now achieves all the desired objectives and remains scalable.