### PR TITLE
Remove tsconfig.tsbuildinfo from repo and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pnpm-debug.log*
 .vscode/
 .idea/
 *.swp
+
+# TypeScript build info
+*.tsbuildinfo

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.test.tsx","./src/app.tsx","./src/main.tsx","./src/setuptests.ts","./src/vite-env.d.ts"],"version":"5.6.3"}


### PR DESCRIPTION
Why
--
- `tsbuildinfo` is automatically generated and system-specific, so committing it to version control is unnecessary and could lead to inconsistencies between different environments.

How
--
- Add it to the `.gitignore`
- Delete the file from the repo
