### PR TITLE
Add Achievements page content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { About } from "./pages/About";
+import { Achievements } from "./pages/Achievements";
 import { Hero } from "./pages/Hero";
 
 function App() {
   return (
-    <>
+    <main>
       <Hero />
       <About />
-    </>
+      <Achievements />
+    </main>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,12 @@ p {
   font: inherit;
   vertical-align: baseline;
 }
+
+ul {
+  padding: 0 1rem;
+}
+
+.hidden {
+  position: absolute;
+  clip-path: inset(100%);
+}

--- a/src/pages/About.test.tsx
+++ b/src/pages/About.test.tsx
@@ -9,6 +9,13 @@ describe("About", () => {
     expect(screen.getByText("Developer")).toBeInTheDocument();
   });
 
+  it("renders h2", () => {
+    render(<About />);
+    const h2 = screen.getByRole("heading");
+    expect(h2).toBeInTheDocument();
+    expect(h2).toHaveTextContent("About");
+  });
+
   it("renders specialize in people content", () => {
     render(<About />);
     expect(screen.getByText(/I specialize in/)).toBeInTheDocument();

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -94,16 +94,9 @@ export const About = () => {
         display: flex;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
-        padding: ${theme.spacing.lg};
       `}
     >
-      <h2
-        className={css`
-          display: none;
-        `}
-      >
-        About
-      </h2>
+      <h2 className="hidden">About</h2>
       <div
         className={css`
           display: flex;
@@ -111,6 +104,7 @@ export const About = () => {
           gap: ${theme.spacing.xl};
           max-width: 80vw;
           margin: auto;
+          padding: ${theme.spacing.lg};
         `}
       >
         <OneBoldDeveloper />

--- a/src/pages/Achievements.test.tsx
+++ b/src/pages/Achievements.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { Achievements } from "./Achievements";
+
+describe("Achievements", () => {
+  it("renders tagline", () => {
+    render(<Achievements />);
+    expect(
+      screen.getByText("Some of my key achievements include:")
+    ).toBeInTheDocument();
+  });
+
+  it("renders h2", () => {
+    render(<Achievements />);
+    const h2 = screen.getByRole("heading");
+    expect(h2).toBeInTheDocument();
+    expect(h2).toHaveTextContent("Achievements");
+  });
+});

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -1,0 +1,79 @@
+import { css } from "@emotion/css";
+import { theme } from "../theme";
+
+export const Achievements = () => {
+  return (
+    <div
+      className={css`
+        display: flex;
+        min-height: 100vh;
+        background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+      `}
+    >
+      <h2 className="hidden">Achievements</h2>
+
+      <div
+        className={css`
+          padding: ${theme.spacing.lg};
+        `}
+      >
+        Some of my key achievements include:
+        <ul
+          className={css`
+            display: flex;
+            flex-direction: column;
+            gap: ${theme.spacing.lg};
+          `}
+        >
+          <li>
+            <strong>Drove a 100% increase in deposits</strong> at a fintech
+            startup by developing a cutting-edge mobile check deposit system
+            with AI-powered text recognition.
+          </li>
+          <li>
+            <strong>Won the "Champion of Process Improvement" award</strong> for
+            streamlining engineering workflows and enhancing efficiency,
+            improving developer velocity across teams.
+          </li>
+          <li>
+            <strong>Led cross-functional teams of 10-20 engineers</strong>{" "}
+            across IoT, manufacturing, ecommerce, and fintech projects; driving
+            architecture decisions, best practices, and delivery of high-quality
+            software.
+          </li>
+          <li>
+            <strong>Founded a Front-End Guild</strong> to mentor dozens of
+            engineers, standardize best practices, and improve collaboration—an
+            initiative so impactful that it led to the creation of additional
+            discipline-based guilds across the organization.
+          </li>
+          <li>
+            <strong>
+              Reduced UI development time and established brand user-experience
+            </strong>{" "}
+            by building a scalable, reusable proprietary React component
+            library, ensuring design consistency across company projects.
+          </li>
+          <li>
+            <strong>Achieved WCAG AA compliance</strong> across enterprise
+            software by advocating for and implementing accessibility standards,
+            enhancing usability for tens of thousands of users and unlocking new
+            business opportunities.
+          </li>
+          <li>
+            <strong>Improved developer productivity and code quality</strong> by
+            optimizing TypeScript configurations, streamlining workflows, and
+            proactively identifying and resolving defects early in the
+            development cycle.
+          </li>
+          <li>
+            <strong>Reduced manual QA testing time by more than 60%</strong> by
+            implementing comprehensive unit and end-to-end testing with Jest,
+            Vitest, and Playwright, significantly improving test reliability and
+            catching regressions early.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Hero.test.tsx
+++ b/src/pages/Hero.test.tsx
@@ -7,6 +7,13 @@ describe("Hero", () => {
     expect(screen.getByText("CF")).toBeInTheDocument();
   });
 
+  it("renders h1", () => {
+    render(<Hero />);
+    const h1 = screen.getByRole("heading");
+    expect(h1).toBeInTheDocument();
+    expect(h1).toHaveTextContent("Chris Flinchbaugh");
+  });
+
   it("renders name", () => {
     render(<Hero />);
     expect(screen.getByText("Chris Flinchbaugh")).toBeInTheDocument();


### PR DESCRIPTION
Why
--
- As a user viewing the portfolio, I should see a summary of meaningful achievements

How
--
- Update App to include `<main>` for accessibility reasons
- Reset `ul` css; add `.hidden` for accessible, invisible text
- Add tests for invisible headings
- Add `Achievements` file with text

Notes
--
- `Achievements` adds meaningful content but is only minimally styled at this time