### PR TITLE
Add multiple projects (Learnolotl, DiDi) 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { About } from "./pages/About";
 import { Achievements } from "./pages/Achievements";
 import { Hero } from "./pages/Hero";
+import { Projects } from "./pages/Projects";
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Hero />
       <About />
       <Achievements />
+      <Projects />
     </main>
   );
 }

--- a/src/components/Project.test.tsx
+++ b/src/components/Project.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { Project } from "./Project";
+import { type Project as ProjectData } from "../hooks/useProjects";
+
+const data: ProjectData = {
+  name: "Name",
+  subheader: "Subheader",
+  approach: "How its done",
+  challenges: "What needs done",
+  description: "What it is",
+  impact: "What result",
+  links: [
+    {
+      name: "Link",
+      url: "https://www.google.com",
+    },
+  ],
+  tags: ["First", "Second", "Third"],
+};
+
+describe("Project", () => {
+  it("renders the required data", () => {
+    render(<Project {...data} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Subheader")).toBeInTheDocument();
+    expect(screen.getByText("How its done")).toBeInTheDocument();
+    expect(screen.getByText("What needs done")).toBeInTheDocument();
+    expect(screen.getByText("What it is")).toBeInTheDocument();
+    expect(screen.getByText("What result")).toBeInTheDocument();
+
+    // Each individual tag
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+    expect(screen.getByText("Third")).toBeInTheDocument();
+  });
+
+  describe("when links are passed it", () => {
+    it("renders each link", () => {
+      render(<Project {...data} />);
+
+      expect(screen.queryByTestId("project-links")).toBeDefined();
+      expect(screen.getByText("Link")).toHaveAttribute(
+        "href",
+        "https://www.google.com"
+      );
+    });
+  });
+
+  describe("when no links are passed it", () => {
+    it("does not render the links section", () => {
+      const updatedData = {
+        ...data,
+        links: undefined,
+      };
+      render(<Project {...updatedData} />);
+
+      expect(screen.queryByTestId("project-links")).toBeNull();
+    });
+  });
+});

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -1,0 +1,105 @@
+import { css } from "@emotion/css";
+import { theme } from "../theme";
+import { type Project as ProjectData } from "../hooks/useProjects";
+
+type ProjectProps = ProjectData;
+
+export const Project = ({
+  approach,
+  challenges,
+  description,
+  impact,
+  links = [],
+  name,
+  subheader,
+  tags,
+}: ProjectProps) => {
+  return (
+    <div
+      className={css`
+        display: flex;
+        flex-direction: column;
+        gap: ${theme.spacing.md};
+      `}
+    >
+      <h3
+        className={css`
+          font-size: ${theme.fontSizes.xl};
+        `}
+      >
+        <strong>{name}</strong>
+      </h3>
+      <div>{subheader}</div>
+
+      <div>
+        <h4>
+          <strong>Description</strong>
+        </h4>
+
+        <div>{description}</div>
+      </div>
+
+      {Boolean(links.length) && (
+        <div
+          data-testid="project-links"
+          className={css`
+            display: flex;
+            flex-direction: row;
+            gap: ${theme.spacing.md};
+          `}
+        >
+          {links.map((link) => (
+            <a href={link.url} key={link.name} target="_blank">
+              {link.name}
+            </a>
+          ))}
+        </div>
+      )}
+
+      <div
+        className={css`
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+          gap: ${theme.spacing.sm};
+        `}
+      >
+        {tags.map((tag) => (
+          <div
+            className={css`
+              font-size: ${theme.fontSizes.xs};
+              border: solid 1px;
+              border-radius: ${theme.spacing.lg};
+              padding: ${theme.spacing.sm};
+            `}
+            key={tag}
+          >
+            {tag}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <h4>
+          <strong>Challenges</strong>
+        </h4>
+
+        <div>{challenges}</div>
+      </div>
+      <div>
+        <h4>
+          <strong>Approach</strong>
+        </h4>
+
+        <div>{approach}</div>
+      </div>
+      <div>
+        <h4>
+          <strong>Impact</strong>
+        </h4>
+
+        <div>{impact}</div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+
+export type Project = {
+  approach: string;
+  challenges: string;
+  description: string;
+  impact: string;
+  links?: {
+    name: string;
+    url: string;
+  }[];
+  name: string;
+  subheader: string;
+  tags: string[];
+};
+
+const projects: Project[] = [
+  {
+    name: "Learnalotl",
+    subheader: "A language learning flashcard web app",
+    approach:
+      "Initially, Learnalotl was built as a personal study tool for Japanese, focusing on rendering n-sided flashcards with hardcoded data. Once the core functionality was solid, I iterated on the UI and added support for user-generated content, making the app more versatile for a broader audience.",
+    challenges:
+      "Designing an intuitive system for user-generated flashcards while ensuring a seamless experience for non-technical users was a major challenge. Balancing simplicity with flexibility required refining the UI/UX and creating an efficient JSON import/export system.",
+    description:
+      "Learnolotl is a web app designed to improve upon traditional flashcards by supporting multiple representations of a word (English, Romaji, Hiragana, Katakana, and Kanji). To enhance usability, I implemented a dynamic form that allows users to create and load their own flashcard decks via JSON files, making the app highly customizable for different study needs.",
+    impact:
+      "This was one of the first projects I independently conceived, designed, built, and deployed. It solved a real-world problem I faced daily, making language study more efficient and engaging. Additionally, it provided valuable experience in UI/UX design, state management with Redux, and front-end architecture, which I later applied in professional settings.",
+    links: [
+      {
+        name: "Demo",
+        url: "https://cflinchbaugh.github.io/Learnolotl/",
+      },
+      {
+        name: "Repo",
+        url: "https://github.com/cflinchbaugh/Learnolotl",
+      },
+    ],
+    tags: [
+      "React",
+      "Redux",
+      "Jest",
+      "Babel",
+      "Webpack",
+      "UI/UX Design",
+      "GitHub Pages",
+      "Node",
+      "Styled Components",
+    ],
+  },
+  {
+    name: "DiDi & Smiling Johns",
+    subheader: "small business website (deprecated)",
+    approach:
+      "I worked closely with the business owners to define their goals, prioritizing an engaging and personality-driven online presence. Through an iterative design process, I incorporated their feedback to create an accessible website featuring individual staff spotlights, a strong call to action, and interactive elements that highlighted the shop's welcoming atmosphere. To ensure maintainability, I implemented a custom CMS integration, allowing them to update select content safely while preserving design integrity. The final design struck a balance between individuality and brand cohesion, using color schemes, group photos, and layout consistency to unify the dual business.",
+    challenges:
+      "Building a website for a dual barber/salon required balancing individuality and cohesion—each stylist needed a personalized section while maintaining a unified brand identity. The business owners also wanted the ability to edit content with minimal risk, necessitating a custom CMS solution that was both flexible and easy to use. It was important to the core identity of the business that the website be inclusive and accessible, as well as accommodate a rotating staff, requiring a structure that could easily adapt to changes.",
+    description:
+      "This is a website I designed and coded for a local business pro-bono to help unify their branding and improve their web presence. They were looking to show each professional as an individual with their own specialties and prices, but also provide cohesion to reflect how closely they worked together. To achieve this, I focused on separating each person and providing them a card with their details while directing focus to groupshots and and increased the use of their branding colors to provide unity.",
+    impact:
+      "The website successfully increased customer engagement and boosted bookings by over 100%, giving the business a much-needed online presence. Customers frequently praised the site's design and usability, reinforcing the brand's credibility. The site remained active for several years, supporting the business until its closure due to pandemic-era challenges and ownership changes.",
+    links: [
+      {
+        name: "Website (Archived)",
+        url: "https://web.archive.org/web/20220308053756/https:/www.didiandsmilingjohns.com/",
+      },
+    ],
+    tags: [
+      "React",
+      "UI/UX Design",
+      "WordPress",
+      "Styled Components",
+      "Accessibility (a11y)",
+      "Responsive Design",
+      "Mobile First",
+      "CMS Integration",
+      "SEO Optimization",
+      "Web Deployment",
+    ],
+  },
+];
+
+export const useProjects = () => {
+  return useMemo(() => projects, []);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,13 @@ ul {
   position: absolute;
   clip-path: inset(100%);
 }
+
+.frosted-glass {
+  background: rgba(255, 255, 255, 0.1); /* Semi-transparent white */
+  backdrop-filter: blur(10px); /* Frosted effect */
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* slight shadow */
+  padding: 20px;
+  border: 2px solid rgba(255, 255, 255, 0.3); /* border with subtle transparency */
+  margin: auto;
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -18,11 +18,8 @@ const OneBoldDeveloper = () => {
       </span>
       <span
         className={css`
-          font-size: 2rem;
+          font-size: 1.5rem;
           padding: ${theme.spacing.sm};
-          ${theme.mq.md} {
-            font-size: 5rem;
-          }
           ${theme.mq.md} {
             font-size: 10rem;
           }
@@ -92,62 +89,75 @@ export const About = () => {
     <div
       className={css`
         display: flex;
+        flex-direction: column;
+        margin: auto;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+        padding: ${theme.spacing.lg};
       `}
     >
       <h2 className="hidden">About</h2>
-      <div
-        className={css`
-          display: flex;
-          flex-direction: column;
-          gap: ${theme.spacing.xl};
-          max-width: 80vw;
-          margin: auto;
-          padding: ${theme.spacing.lg};
-        `}
-      >
-        <OneBoldDeveloper />
 
+      <div
+        className={
+          css`
+            margin: auto;
+            max-width: 80vw;
+          ` + " frosted-glass"
+        }
+      >
         <div
           className={css`
-            ${theme.mq.md} {
-              margin-bottom: ${theme.spacing.xl};
-            }
+            display: flex;
+            flex-direction: column;
+            gap: ${theme.spacing.xl};
+            max-width: 80vw;
+            margin: auto;
           `}
         >
-          <strong>Hi, I'm Chris-</strong> a software engineer with over a decade
-          of experience building scalable, user-focused applications. My passion
-          lies in crafting intuitive and performant experiences using modern
-          frameworks like React and React Native, but I have a strong background
-          in API integration, architecture optimization, and testing.
-        </div>
+          <OneBoldDeveloper />
 
-        <div>
           <div
             className={css`
-              display: flex;
-              flex-direction: column;
-              gap: ${theme.spacing.xl};
               ${theme.mq.md} {
-                flex-direction: row;
+                margin-bottom: ${theme.spacing.xl};
               }
             `}
           >
-            <div
-              className={css`
-                flex: 1;
-              `}
-            >
-              <People />
-            </div>
+            <strong>Hi, I'm Chris-</strong> a software engineer with over a
+            decade of experience building scalable, user-focused applications.
+            My passion lies in crafting intuitive and performant experiences
+            using modern frameworks like React and React Native, but I have a
+            strong background in API integration, architecture optimization, and
+            testing.
+          </div>
 
+          <div>
             <div
               className={css`
-                flex: 1;
+                display: flex;
+                flex-direction: column;
+                gap: ${theme.spacing.xl};
+                ${theme.mq.md} {
+                  flex-direction: row;
+                }
               `}
             >
-              <Problems />
+              <div
+                className={css`
+                  flex: 1;
+                `}
+              >
+                <People />
+              </div>
+
+              <div
+                className={css`
+                  flex: 1;
+                `}
+              >
+                <Problems />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -6,73 +6,88 @@ export const Achievements = () => {
     <div
       className={css`
         display: flex;
+        flex-direction: column;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+        padding: ${theme.spacing.lg};
       `}
     >
       <h2 className="hidden">Achievements</h2>
 
       <div
-        className={css`
-          padding: ${theme.spacing.lg};
-        `}
+        className={
+          css`
+            max-width: 80vw;
+          ` + " frosted-glass"
+        }
       >
-        Some of my key achievements include:
-        <ul
+        <div
           className={css`
             display: flex;
             flex-direction: column;
-            gap: ${theme.spacing.lg};
+            gap: ${theme.spacing.xl};
+            max-width: 80vw;
           `}
         >
-          <li>
-            <strong>Drove a 100% increase in deposits</strong> at a fintech
-            startup by developing a cutting-edge mobile check deposit system
-            with AI-powered text recognition.
-          </li>
-          <li>
-            <strong>Won the "Champion of Process Improvement" award</strong> for
-            streamlining engineering workflows and enhancing efficiency,
-            improving developer velocity across teams.
-          </li>
-          <li>
-            <strong>Led cross-functional teams of 10-20 engineers</strong>{" "}
-            across IoT, manufacturing, ecommerce, and fintech projects; driving
-            architecture decisions, best practices, and delivery of high-quality
-            software.
-          </li>
-          <li>
-            <strong>Founded a Front-End Guild</strong> to mentor dozens of
-            engineers, standardize best practices, and improve collaboration—an
-            initiative so impactful that it led to the creation of additional
-            discipline-based guilds across the organization.
-          </li>
-          <li>
-            <strong>
-              Reduced UI development time and established brand user-experience
-            </strong>{" "}
-            by building a scalable, reusable proprietary React component
-            library, ensuring design consistency across company projects.
-          </li>
-          <li>
-            <strong>Achieved WCAG AA compliance</strong> across enterprise
-            software by advocating for and implementing accessibility standards,
-            enhancing usability for tens of thousands of users and unlocking new
-            business opportunities.
-          </li>
-          <li>
-            <strong>Improved developer productivity and code quality</strong> by
-            optimizing TypeScript configurations, streamlining workflows, and
-            proactively identifying and resolving defects early in the
-            development cycle.
-          </li>
-          <li>
-            <strong>Reduced manual QA testing time by more than 60%</strong> by
-            implementing comprehensive unit and end-to-end testing with Jest,
-            Vitest, and Playwright, significantly improving test reliability and
-            catching regressions early.
-          </li>
-        </ul>
+          Some of my key achievements include:
+          <ul
+            className={css`
+              display: flex;
+              flex-direction: column;
+              gap: ${theme.spacing.lg};
+            `}
+          >
+            <li>
+              <strong>Drove a 100% increase in deposits</strong> at a fintech
+              startup by developing a cutting-edge mobile check deposit system
+              with AI-powered text recognition.
+            </li>
+            <li>
+              <strong>Won the "Champion of Process Improvement" award</strong>{" "}
+              for streamlining engineering workflows and enhancing efficiency,
+              improving developer velocity across teams.
+            </li>
+            <li>
+              <strong>Led cross-functional teams of 10-20 engineers</strong>{" "}
+              across IoT, manufacturing, ecommerce, and fintech projects;
+              driving architecture decisions, best practices, and delivery of
+              high-quality software.
+            </li>
+            <li>
+              <strong>Founded a Front-End Guild</strong> to mentor dozens of
+              engineers, standardize best practices, and improve
+              collaboration—an initiative so impactful that it led to the
+              creation of additional discipline-based guilds across the
+              organization.
+            </li>
+            <li>
+              <strong>
+                Reduced UI development time and established brand
+                user-experience
+              </strong>{" "}
+              by building a scalable, reusable proprietary React component
+              library, ensuring design consistency across company projects.
+            </li>
+            <li>
+              <strong>Achieved WCAG AA compliance</strong> across enterprise
+              software by advocating for and implementing accessibility
+              standards, enhancing usability for tens of thousands of users and
+              unlocking new business opportunities.
+            </li>
+            <li>
+              <strong>Improved developer productivity and code quality</strong>{" "}
+              by optimizing TypeScript configurations, streamlining workflows,
+              and proactively identifying and resolving defects early in the
+              development cycle.
+            </li>
+            <li>
+              <strong>Reduced manual QA testing time by more than 60%</strong>{" "}
+              by implementing comprehensive unit and end-to-end testing with
+              Jest, Vitest, and Playwright, significantly improving test
+              reliability and catching regressions early.
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,0 +1,37 @@
+import { css } from "@emotion/css";
+import { theme } from "../theme";
+import { Project } from "../components/Project";
+import { useProjects } from "../hooks/useProjects";
+
+export const Projects = () => {
+  const projectData = useProjects();
+
+  return (
+    <div
+      className={css`
+        display: flex;
+        flex-direction: column;
+        margin: auto;
+        gap: ${theme.spacing.lg};
+        min-height: 100vh;
+        background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+        padding: ${theme.spacing.lg};
+      `}
+    >
+      <h2 className="hidden">Projects</h2>
+      {projectData.map((project) => (
+        <div
+          className={
+            css`
+              margin: auto;
+              max-width: 80vw;
+            ` + " frosted-glass"
+          }
+          key={project.name}
+        >
+          <Project key={project.name} {...project} />
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
Why
--
- As a user viewing the portfolio, I should see projects with meaningful information

How
--
- Add the new Projects page
- Add a Project component for consistent formatting
- Add `useProject` hook for data abstraction
- Update existing pages for more consistent layout spacing

Notes
--
- `useProject` could just as easily be a file which directly exports const data, but this better prepares for API integration in the event I decide to store this data in a DB.
- This PR will be followed up with additional projects as well as images, but it is a meaningful step forward at this time and would unblock others from adding Project info if this were a team-based project.