### PR TITLE
Update padding for better use of mobile spacing

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -93,7 +93,7 @@ export const About = () => {
         margin: auto;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
-        padding: ${theme.spacing.lg};
+        padding: ${theme.spacing.sm};
       `}
     >
       <h2 className="hidden">About</h2>

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -9,7 +9,7 @@ export const Achievements = () => {
         flex-direction: column;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
-        padding: ${theme.spacing.lg};
+        padding: ${theme.spacing.sm};
       `}
     >
       <h2 className="hidden">Achievements</h2>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -14,7 +14,7 @@ export const Contact = () => {
         margin: auto;
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
-        padding: ${theme.spacing.lg};
+        padding: ${theme.spacing.sm};
       `}
     >
       <h2 className="hidden">Contact</h2>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -15,7 +15,10 @@ export const Projects = () => {
         gap: ${theme.spacing.lg};
         min-height: 100vh;
         background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
-        padding: ${theme.spacing.lg};
+        padding: ${theme.spacing.sm};
+
+        ${theme.mq.md} {
+        padding: ${theme.spacing.lg} ${theme.spacing.sm}
       `}
     >
       <h2 className="hidden">Projects</h2>


### PR DESCRIPTION
Why
--
- As a user viewing the portfolio on a small mobile screen, I should see more space dedicated to content and less negative-space

How
--
- Update padding usage across main containers

Notes
--
- I may yet convert these divs into a reusable component to reduce redundancy; the decision will be made when the current design iteration is finalized.