### PR TITLE
Add Skills content, Carousel component, and apply `.container-card` class

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Contact } from "./pages/Contact";
 import { Hero } from "./pages/Hero";
 
 import { Suspense, lazy } from "react";
+import { Skills } from "./pages/Skills";
 const Projects = lazy(() => import("./pages/Projects"));
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
       <Suspense fallback={<div>Loading...</div>}>
         <Projects />
       </Suspense>
+      <Skills />
       <Contact />
     </main>
   );

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,0 +1,129 @@
+import { css } from "@emotion/css";
+import { Children, useState, ReactNode } from "react";
+import { theme } from "../theme";
+
+interface CarouselProps {
+  children: ReactNode;
+}
+
+const containerStyle = css`
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  overflow: hidden;
+  margin: auto;
+  perspective: 1200px; /* Enables 3D perspective */
+  height: 90vh;
+  align-content: center;
+`;
+
+const trackStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 300px; /* Adjust based on content */
+`;
+
+const slideStyle = (
+  index: number,
+  currentIndex: number,
+  totalSlides: number
+) => css`
+  position: absolute;
+  width: 90%;
+  ${theme.mq.md} {
+    width: 70%;
+  }
+  max-width: 500px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+  transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
+
+  ${index === currentIndex
+    ? `
+      transform: translateZ(0) scale(1); /* Active */
+      opacity: 1;
+      z-index: 2;
+    `
+    : index === (currentIndex + 1) % totalSlides
+    ? `
+      transform: translateX(-30%) translateY(10%) translateZ(-200px) scale(0.8); /* Next */
+      opacity: 0.7;
+      z-index: 1;
+    `
+    : index === (currentIndex - 1 + totalSlides) % totalSlides
+    ? `
+      transform: translateX(30%) translateY(-10%) translateZ(-400px) scale(0.6); /* Previous */
+      opacity: 0.5;
+      z-index: 0;
+    `
+    : `
+      display: none; /* Hide all other slides */
+    `}
+`;
+
+const buttonStyle = css`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  cursor: pointer;
+  padding: 10px;
+  z-index: 3;
+`;
+
+const prevButtonStyle = css`
+  ${buttonStyle}
+  left: 10px;
+`;
+
+const nextButtonStyle = css`
+  ${buttonStyle}
+  right: 10px;
+`;
+
+export const Carousel = ({ children }: CarouselProps) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const totalSlides = Children.count(children);
+
+  const nextSlide = () => {
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % totalSlides);
+  };
+
+  const prevSlide = () => {
+    setCurrentIndex((prevIndex) => (prevIndex - 1 + totalSlides) % totalSlides);
+  };
+
+  return (
+    <div className={containerStyle}>
+      <button onClick={prevSlide} className={prevButtonStyle}>
+        ‹
+      </button>
+
+      <div className={trackStyle}>
+        {Children.map(children, (child, index) => (
+          <div
+            key={index}
+            className={slideStyle(index, currentIndex, totalSlides)}
+          >
+            {child}
+          </div>
+        ))}
+      </div>
+
+      <button onClick={nextSlide} className={nextButtonStyle}>
+        ›
+      </button>
+    </div>
+  );
+};
+
+export default Carousel;

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -50,11 +50,11 @@ export const ProjectItem = ({
               background-repeat: no-repeat;
               background-position: center;
 
-              ${theme.mq.lg} {
+              ${theme.mq.md} {
                 background-image: url("${imageName}-600.avif");
               }
 
-              ${theme.mq.xl} {
+              ${theme.mq.lg} {
                 background-image: url("${imageName}-1280.avif");
               }
             ` + " fade-in"

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+
+type Skill = {
+  name: string;
+  details: string[];
+  icon?: React.ReactNode;
+};
+
+const skills: Skill[] = [
+  {
+    name: "Frontend Development",
+    details: [
+      "React.js & React Native - Expertise in building dynamic, high-performance web and mobile applications. Experience includes state management (Redux.js), performance optimizations, and React Dev Tools.",
+      "TypeScript & JavaScript - Strong proficiency in modern JavaScript (ES6+) for scalable, maintainable applications.",
+      "CSS & Styling - Skilled in Tailwind CSS, SASS, Bootstrap, and traditional CSS for responsive, accessible UI design.",
+      "Adaptive & Responsive Design - Ensuring seamless user experiences across devices and screen sizes.",
+    ],
+    icon: "🌐",
+  },
+  {
+    name: "Testing & Quality Assurance",
+    details: [
+      "Unit & Integration Testing - Experienced with Jest, Vitest for unit tests and integration testing.",
+      "End-to-End Testing - Proficient in Cypress & Playwright for UI automation and regression testing.",
+      "CI/CD & Automation - Using GitHub Actions to automate testing and linting in development workflows.",
+    ],
+    icon: "🧪",
+  },
+  {
+    name: "Backend & API Development",
+    details: [
+      "GraphQL & REST APIs - Built and consumed APIs, including developing a GraphQL API for a full-stack project.",
+      "Database Experience - Worked with MongoDB & Supabase (PostgreSQL-based) for data storage solutions.",
+      "Authentication & Security - Implemented Google Auth and integrated secure session token authentication via API endpoints.,",
+    ],
+    icon: "🔗",
+  },
+  {
+    name: "Performance Optimization",
+    details: [
+      "Lighthouse & React Dev Tools - Regularly optimize performance using auditing tools.",
+      "Lazy Loading & Code Splitting - Reduce initial load times by deferring non-critical assets and dynamically loading modules.",
+      "Image Optimization - Implementing best practices like AVIF/WebP, responsive image sizing, and content visibility techniques.",
+    ],
+    icon: "⚡",
+  },
+  {
+    name: "Accessibility & Inclusive Design",
+    details: [
+      "WCAG 2.1 AA Compliance - Ensured enterprise software met high accessibility standards.",
+      "Section 508 Compliance - Experience implementing compliance best practices in government and corporate environments.",
+      "Accessibility Testing Tools - Regular use of WAVE browser extension and manual testing to improve usability.",
+    ],
+    icon: "♿",
+  },
+  {
+    name: "AI & Computer Vision",
+    details: [
+      "AI Text Recognition - Implemented React Native Vision Camera for scanning and processing text in real-time applications.",
+      "AI Prompt Engineering - Experience refining and structuring AI-driven interactions for better contextual accuracy.",
+    ],
+  },
+  {
+    name: "Project Management & Leadership",
+    details: [
+      "Mentorship & Team Leadership - Founded a Front-end Guild to mentor and support developers.",
+      "Code Reviews & Best Practices - Regularly conducted code reviews and established company-wide frontend standards.",
+      "Agile & Feature Prioritization - Worked in Agile environments with a focus on efficient feature planning and delivery.",
+    ],
+  },
+  {
+    name: "DevOps & Developer Tools",
+    details: [
+      "Version Control & Collaboration - Proficient in Git, GitHub, and remote team collaboration tools.",
+      "CI/CD Pipelines - Experience setting up automated deployment and testing workflows.",
+      "Developer Productivity Tools - Comfortable with Vite, Webpack, and debugging utilities to streamline development.",
+    ],
+  },
+];
+
+export const useSkills = () => {
+  return useMemo(() => skills, []);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@ body,
 div,
 span,
 h1,
-/* h2, */
+h2,
 h3,
 h4,
 h5,

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,15 @@ ul {
   margin: auto;
 }
 
+.container-card {
+  max-width: 80vw;
+}
+@media screen and (min-width: 1200px) {
+  .container-card {
+    max-width: 60vw;
+  }
+}
+
 /* Define the fade-in animation */
 .fade-in {
   opacity: 0.2; /* Initially hidden */

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@ body,
 div,
 span,
 h1,
-h2,
+/* h2, */
 h3,
 h4,
 h5,

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -105,18 +105,18 @@ export const About = () => {
         className={
           css`
             margin: auto;
-            max-width: 80vw;
-          ` + " frosted-glass fade-in"
+          ` + " container-card frosted-glass fade-in"
         }
       >
         <div
-          className={css`
-            display: flex;
-            flex-direction: column;
-            gap: ${theme.spacing.xl};
-            max-width: 80vw;
-            margin: auto;
-          `}
+          className={
+            css`
+              display: flex;
+              flex-direction: column;
+              gap: ${theme.spacing.xl};
+              margin: auto;
+            ` + " container-card"
+          }
         >
           <OneBoldDeveloper />
 

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -14,20 +14,15 @@ export const Achievements = () => {
     >
       <h2 className="hidden">Achievements</h2>
 
-      <div
-        className={
-          css`
-            max-width: 80vw;
-          ` + " frosted-glass"
-        }
-      >
+      <div className="container-card frosted-glass">
         <div
-          className={css`
-            display: flex;
-            flex-direction: column;
-            gap: ${theme.spacing.xl};
-            max-width: 80vw;
-          `}
+          className={
+            css`
+              display: flex;
+              flex-direction: column;
+              gap: ${theme.spacing.xl};
+            ` + " container-card"
+          }
         >
           Some of my key achievements include:
           <ul

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -26,30 +26,31 @@ export const Contact = () => {
             flex-direction: column;
             gap: ${theme.spacing.md};
             margin: auto;
-            max-width: 80vw;
-          ` + " frosted-glass"
+          ` + " container-card frosted-glass"
         }
       >
         <div
-          className={css`
-            display: flex;
-            flex-direction: column;
-            gap: ${theme.spacing.xl};
-            max-width: 80vw;
-            margin: auto;
-          `}
+          className={
+            css`
+              display: flex;
+              flex-direction: column;
+              gap: ${theme.spacing.xl};
+              margin: auto;
+            ` + " container-card"
+          }
         >
           You've heard a bit about me, I'd love to hear from you.
         </div>
 
         <div
-          className={css`
-            display: flex;
-            flex-direction: row;
-            gap: ${theme.spacing.lg};
-            max-width: 80vw;
-            justify-content: center;
-          `}
+          className={
+            css`
+              display: flex;
+              flex-direction: row;
+              gap: ${theme.spacing.lg};
+              justify-content: center;
+            ` + " container-card"
+          }
         >
           <ImageLink
             alt="LinkedIn Logo"

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -35,8 +35,7 @@ export const Projects = () => {
             className={
               css`
                 margin: auto;
-                max-width: 80vw;
-              ` + " frosted-glass"
+              ` + " container-card frosted-glass"
             }
             key={project.name}
           >

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -3,6 +3,15 @@ import Carousel from "../components/Carousel";
 import { useSkills } from "../hooks/useSkills";
 import { theme } from "../theme";
 
+const skillCardClass = css`
+  margin: auto;
+  padding: ${theme.spacing.md};
+`;
+
+const detailClass = css`
+  padding-bottom: ${theme.spacing.md};
+`;
+
 export const Skills = () => {
   const skillsData = useSkills();
 
@@ -28,9 +37,11 @@ export const Skills = () => {
         `}
       >
         <div
-          className={css`
-            padding: ${theme.spacing.md};
-          `}
+          className={
+            css`
+              padding: 4rem ${theme.spacing.md} 0 ${theme.spacing.md};
+            ` + " container-card"
+          }
         >
           Throughout my career, I've honed a diverse set of skills across
           various projects—many of them proprietary. Below, you'll find a
@@ -41,27 +52,16 @@ export const Skills = () => {
         <Carousel>
           {skillsData.map((skill) => (
             <div
-              className={
-                css`
-                  margin: auto;
-                  max-width: 80vw;
-                  padding: ${theme.spacing.md};
-                `
-                // ` + " frosted-glass"
-              }
+              className={`${skillCardClass} container-card`}
               key={skill.name}
             >
               <h3 className="text-xl font-semibold flex items-center gap-2">
-                <span>{skill.icon}</span> {skill.name}
+                <span>{skill.icon}</span> <strong>{skill.name}</strong>
               </h3>
 
               <ul>
-                {skill.details.map((detail) => (
-                  <li
-                    className={css`
-                      padding-bottom: ${theme.spacing.md};
-                    `}
-                  >
+                {skill.details.map((detail, index) => (
+                  <li className={detailClass} key={`${skill.name}-${index}`}>
                     {detail}
                   </li>
                 ))}

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -1,0 +1,75 @@
+import { css } from "@emotion/css";
+import Carousel from "../components/Carousel";
+import { useSkills } from "../hooks/useSkills";
+import { theme } from "../theme";
+
+export const Skills = () => {
+  const skillsData = useSkills();
+
+  return (
+    <div
+      className={css`
+        display: flex;
+        flex-direction: column;
+        margin: auto;
+        min-height: 100vh;
+        background: linear-gradient(to bottom, #fe8a75 0%, #b5cbed 100%);
+        padding: ${theme.spacing.sm};
+      `}
+    >
+      <h2 className="hidden">Skills & Experience</h2>
+
+      <div
+        className={css`
+          margin: auto;
+          display: flex;
+          flex-direction: column;
+          gap: ${theme.spacing.lg};
+        `}
+      >
+        <div
+          className={css`
+            padding: ${theme.spacing.md};
+          `}
+        >
+          Throughout my career, I've honed a diverse set of skills across
+          various projects—many of them proprietary. Below, you'll find a
+          selection of these skills, each contributing to my ability to tackle
+          new challenges with confidence and efficiency.
+        </div>
+
+        <Carousel>
+          {skillsData.map((skill) => (
+            <div
+              className={
+                css`
+                  margin: auto;
+                  max-width: 80vw;
+                  padding: ${theme.spacing.md};
+                `
+                // ` + " frosted-glass"
+              }
+              key={skill.name}
+            >
+              <h3 className="text-xl font-semibold flex items-center gap-2">
+                <span>{skill.icon}</span> {skill.name}
+              </h3>
+
+              <ul>
+                {skill.details.map((detail) => (
+                  <li
+                    className={css`
+                      padding-bottom: ${theme.spacing.md};
+                    `}
+                  >
+                    {detail}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </Carousel>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Why
--
- As a user viewing the portfolio, I should see a list of skills that do not appear in the Projects section
- As a developer working in the codebase, I should have a standard sizing option to address different viewports (`.container-card`)

How
--
- Update `App` to include new `Skills` page
- Add `Carousel` component
- Update `ProjectItem` media queries to use higher resolution images
- Add `useSkills` hook for skill data
- Add `.container-card` class
- Update pages with `.container-card` class
- Add `Skills` page

Notes
--
- `.container-card` updates address styling issues on extra wide or high resolution monitors, specifically.