### PR TITLE
Update page headings to visibly render, streamline class usage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,11 @@ ul {
   padding: 0 1rem;
 }
 
+.page-heading {
+  font-size: x-large;
+  padding-bottom: 2rem;
+  font-weight: bolder;
+}
 .hidden {
   position: absolute;
   clip-path: inset(100%);
@@ -64,10 +69,12 @@ ul {
 
 .container-card {
   max-width: 80vw;
+  margin: auto;
+  padding: 2rem 0;
 }
 @media screen and (min-width: 1200px) {
   .container-card {
-    max-width: 60vw;
+    max-width: 70vw;
   }
 }
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -99,67 +99,70 @@ export const About = () => {
         padding: ${theme.spacing.sm};
       `}
     >
-      <h2 className="hidden">About</h2>
+      <div className="container-card">
+        <h2 className="hidden">About</h2>
 
-      <div
-        className={
-          css`
-            margin: auto;
-          ` + " container-card frosted-glass fade-in"
-        }
-      >
         <div
           className={
             css`
-              display: flex;
-              flex-direction: column;
-              gap: ${theme.spacing.xl};
               margin: auto;
-            ` + " container-card"
+            ` + " container-card frosted-glass fade-in"
           }
         >
-          <OneBoldDeveloper />
-
           <div
-            className={css`
-              ${theme.mq.md} {
-                margin-bottom: ${theme.spacing.xl};
-              }
-            `}
-          >
-            <strong>Hi, I'm Chris-</strong> a software engineer with over a
-            decade of experience building scalable, user-focused applications.
-            My passion lies in crafting intuitive and performant experiences
-            using modern frameworks like React and React Native, but I have a
-            strong background in API integration, architecture optimization, and
-            testing.
-          </div>
-
-          <div>
-            <div
-              className={css`
+            className={
+              css`
                 display: flex;
                 flex-direction: column;
                 gap: ${theme.spacing.xl};
+                padding: ${theme.spacing.xl};
+                margin: auto;
+              ` + " container-card"
+            }
+          >
+            <OneBoldDeveloper />
+
+            <div
+              className={css`
                 ${theme.mq.md} {
-                  flex-direction: row;
+                  margin-bottom: ${theme.spacing.xl};
                 }
               `}
             >
-              <div
-                className={css`
-                  flex: 1;
-                `}
-              >
-                <People />
-              </div>
+              <strong>Hi, I'm Chris-</strong> a software engineer with over a
+              decade of experience building scalable, user-focused applications.
+              My passion lies in crafting intuitive and performant experiences
+              using modern frameworks like React and React Native, but I have a
+              strong background in API integration, architecture optimization,
+              and testing.
+            </div>
 
+            <div>
               <div
                 className={css`
-                  flex: 1;
+                  display: flex;
+                  flex-direction: column;
+                  gap: ${theme.spacing.xl};
+                  ${theme.mq.md} {
+                    flex-direction: row;
+                  }
                 `}
               >
-                <Problems />
+                <div
+                  className={css`
+                    flex: 1;
+                  `}
+                >
+                  <People />
+                </div>
+
+                <div
+                  className={css`
+                    flex: 1;
+                  `}
+                >
+                  <Problems />
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -15,24 +15,23 @@ export const Achievements = () => {
         padding: ${theme.spacing.sm};
       `}
     >
-      <h2 className="hidden">Achievements</h2>
-
-      <div className="container-card frosted-glass">
-        <div
-          className={
-            css`
+      <div className="container-card">
+        <h2 className="page-heading">Achievements</h2>
+        <div className="frosted-glass">
+          <div
+            className={css`
               display: flex;
               flex-direction: column;
               gap: ${theme.spacing.xl};
-            ` + " container-card"
-          }
-        >
-          Some of my key achievements include:
-          {achievementsData.map((item) => (
-            <div key={item.id}>
-              <strong>{item.head}</strong> {item.tail}
-            </div>
-          ))}
+            `}
+          >
+            Some of my key achievements include:
+            {achievementsData.map((item) => (
+              <div key={item.id}>
+                <strong>{item.head}</strong> {item.tail}
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -17,56 +17,56 @@ export const Contact = () => {
         padding: ${theme.spacing.sm};
       `}
     >
-      <h2 className="hidden">Contact</h2>
+      <div className="container-card">
+        <h2 className="hidden">Contact</h2>
 
-      <div
-        className={
-          css`
-            display: flex;
-            flex-direction: column;
-            gap: ${theme.spacing.md};
-            margin: auto;
-          ` + " container-card frosted-glass"
-        }
-      >
         <div
           className={
             css`
               display: flex;
               flex-direction: column;
+              gap: ${theme.spacing.md};
+              margin: auto;
+            ` + " frosted-glass"
+          }
+        >
+          <div
+            className={css`
+              display: flex;
+              flex-direction: column;
               gap: ${theme.spacing.xl};
               margin: auto;
-            ` + " container-card"
-          }
-        >
-          You've heard a bit about me, I'd love to hear from you.
-        </div>
+            `}
+          >
+            You've heard a bit about me, I'd love to hear from you.
+          </div>
 
-        <div
-          className={
-            css`
-              display: flex;
-              flex-direction: row;
-              gap: ${theme.spacing.lg};
-              justify-content: center;
-            ` + " container-card"
-          }
-        >
-          <ImageLink
-            alt="LinkedIn Logo"
-            href="https://www.linkedin.com/in/christopher-flinchbaugh/"
-            src={linkedIn}
-          />
-          <ImageLink
-            alt="Email Logo"
-            href="mailto:christopher.e.flinchbaugh@gmail.com"
-            src={email}
-          />
-          <ImageLink
-            alt="GitHub Logo"
-            href="https://github.com/cflinchbaugh"
-            src={gitHub}
-          />
+          <div
+            className={
+              css`
+                display: flex;
+                flex-direction: row;
+                gap: ${theme.spacing.lg};
+                justify-content: center;
+              ` + " container-card"
+            }
+          >
+            <ImageLink
+              alt="LinkedIn Logo"
+              href="https://www.linkedin.com/in/christopher-flinchbaugh/"
+              src={linkedIn}
+            />
+            <ImageLink
+              alt="Email Logo"
+              href="mailto:christopher.e.flinchbaugh@gmail.com"
+              src={email}
+            />
+            <ImageLink
+              alt="GitHub Logo"
+              href="https://github.com/cflinchbaugh"
+              src={gitHub}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -24,25 +24,29 @@ export const Projects = () => {
         padding: ${theme.spacing.lg} ${theme.spacing.sm}
       `}
     >
-      <h2 className="hidden">Projects</h2>
-      {projectData.map((project, index) => {
-        const data = {
-          ...project,
-          imagePositionStart: Boolean(index % 2),
-        };
-        return (
-          <div
-            className={
-              css`
-                margin: auto;
-              ` + " container-card frosted-glass"
-            }
-            key={project.name}
-          >
-            <ProjectItem key={project.name} {...data} />
-          </div>
-        );
-      })}
+      <div className="container-card">
+        <h2 className="page-heading">Projects</h2>
+
+        <div
+          className={css`
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+          `}
+        >
+          {projectData.map((project, index) => {
+            const data = {
+              ...project,
+              imagePositionStart: Boolean(index % 2),
+            };
+            return (
+              <div className="frosted-glass" key={project.name}>
+                <ProjectItem key={project.name} {...data} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -26,49 +26,42 @@ export const Skills = () => {
         padding: ${theme.spacing.sm};
       `}
     >
-      <h2 className="hidden">Skills & Experience</h2>
+      <div className="container-card">
+        <h2 className="page-heading">Skills & Experience</h2>
 
-      <div
-        className={css`
-          margin: auto;
-          display: flex;
-          flex-direction: column;
-          gap: ${theme.spacing.lg};
-        `}
-      >
         <div
-          className={
-            css`
-              padding: 4rem ${theme.spacing.md} 0 ${theme.spacing.md};
-            ` + " container-card"
-          }
+          className={css`
+            margin: auto;
+            display: flex;
+            flex-direction: column;
+            gap: ${theme.spacing.lg};
+          `}
         >
-          Throughout my career, I've honed a diverse set of skills across
-          various projects—many of them proprietary. Below, you'll find a
-          selection of these skills, each contributing to my ability to tackle
-          new challenges with confidence and efficiency.
+          <div>
+            Throughout my career, I've honed a diverse set of skills across
+            various projects—many of them proprietary. Below, you'll find a
+            selection of these skills, each contributing to my ability to tackle
+            new challenges with confidence and efficiency.
+          </div>
+
+          <Carousel>
+            {skillsData.map((skill) => (
+              <div className={skillCardClass} key={skill.name}>
+                <h3 className="text-xl font-semibold flex items-center gap-2">
+                  <span>{skill.icon}</span> <strong>{skill.name}</strong>
+                </h3>
+
+                <ul>
+                  {skill.details.map((detail, index) => (
+                    <li className={detailClass} key={`${skill.name}-${index}`}>
+                      {detail}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </Carousel>
         </div>
-
-        <Carousel>
-          {skillsData.map((skill) => (
-            <div
-              className={`${skillCardClass} container-card`}
-              key={skill.name}
-            >
-              <h3 className="text-xl font-semibold flex items-center gap-2">
-                <span>{skill.icon}</span> <strong>{skill.name}</strong>
-              </h3>
-
-              <ul>
-                {skill.details.map((detail, index) => (
-                  <li className={detailClass} key={`${skill.name}-${index}`}>
-                    {detail}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </Carousel>
       </div>
     </div>
   );


### PR DESCRIPTION
Why
--
- As a user viewing the content, I should see meaningful headings to reinforce context shifting

How
--
- Add `.page-heading` class
- Replace `hidden` class applied to page headings
- Update DOM hierarchy, container-card is used to apply widths and positioning and should be distinct from the frosted-glass cards to allow for consistent heading positioning