### PR TITLE
Update App with sections tag, set Achievements h3 tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,26 @@ const ProfessionalHistory = lazy(() => import("./pages/ProfessionalHistory"));
 function App() {
   return (
     <main>
-      <Hero />
-      <About />
-      <Achievements />
-      <Suspense fallback={<div>Loading...</div>}>
-        <ProfessionalHistory />
-      </Suspense>
-      <Skills />
-      <Contact />
+      <section>
+        <Hero />
+      </section>
+      <section>
+        <About />
+      </section>
+      <section>
+        <Achievements />
+      </section>
+      <section>
+        <Suspense fallback={<div>Loading...</div>}>
+          <ProfessionalHistory />
+        </Suspense>
+      </section>
+      <section>
+        <Skills />
+      </section>
+      <section>
+        <Contact />
+      </section>
     </main>
   );
 }

--- a/src/pages/Achievements.test.tsx
+++ b/src/pages/Achievements.test.tsx
@@ -4,8 +4,7 @@ import { Achievements } from "./Achievements";
 describe("Achievements", () => {
   it("renders h2", () => {
     render(<Achievements />);
-    const h2 = screen.getByRole("heading");
-    expect(h2).toBeInTheDocument();
-    expect(h2).toHaveTextContent("Professional Achievements");
+    const headings = screen.getAllByRole("heading");
+    expect(headings[0]).toHaveTextContent("Professional Achievements");
   });
 });

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -33,9 +33,9 @@ export const Achievements = () => {
             >
               <div className="flex h-full w-full frosted-glass">
                 <div>
-                  <p className="mb-2 text-2xl font-semibold">
+                  <h3 className="mb-2 text-2xl font-semibold">
                     {achievement.head}
-                  </p>
+                  </h3>
                   <p>{achievement.tail}</p>
                 </div>
               </div>


### PR DESCRIPTION
Why
--
- As a user viewing the website via a screen reader, I should have logically grouped content identified appropriately (sections with headers)

How
--
- Wrap each "page" component in a Section tag
- Update Achievement p tag to h3
- Update Achievement tests