### PR TITLE
Replace previous portfolio-v2 url with revised portfolio url

### DIFF
--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -68,7 +68,7 @@ const projects: Project[] = [
       },
       {
         name: "Repo",
-        url: "https://github.com/cflinchbaugh/portfolio-v2",
+        url: "https://github.com/cflinchbaugh/portfolio",
       },
     ],
     tags: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss()],
-  base: mode === "production" ? "/portfolio-v2/" : "/", // Only set base in production
+  base: mode === "production" ? "/portfolio/" : "/", // Only set base in production
   build: {
     outDir: "dist",
   },


### PR DESCRIPTION
Why
--
- MVP status of portfolio has been achieved, updating the primary URL requires a few dep changes

How
--
- Replace anything pointing at the WIP project name with the revised name