### PR TITLE
Update Achievements to better utilize space across various viewports

### DIFF
--- a/src/hooks/useAchievements.ts
+++ b/src/hooks/useAchievements.ts
@@ -9,8 +9,8 @@ type Achievement = {
 const achievements: Achievement[] = [
   {
     id: 0,
-    head: "Drove a 100% increase in deposits",
-    tail: "at a fintech startup by developing a cutting-edge mobile check deposit system with AI-powered text recognition.",
+    head: "Drove a 100% increase in fintech deposits",
+    tail: "at a startup by developing a cutting-edge mobile check deposit system with AI-powered text recognition.",
   },
   {
     id: 1,
@@ -34,8 +34,8 @@ const achievements: Achievement[] = [
   },
   {
     id: 5,
-    head: "Achieved WCAG AA compliance",
-    tail: "across enterprise software by advocating for and implementing accessibility standards, enhancing usability for tens of thousands of users and unlocking new business opportunities.",
+    head: "Achieved WCAG AA compliance across enterprise software",
+    tail: "by advocating for and implementing accessibility standards, enhancing usability for tens of thousands of users and unlocking new business opportunities.",
   },
   {
     id: 6,

--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -21,7 +21,7 @@ export const Achievements = () => {
       <div className="container-card">
         <h2 className="page-heading">Professional Achievements</h2>
 
-        <div className="grid gap-5 h-full grid-cols-1 md:grid-cols-2 xl:grid-cols-3 xl:grid-rows-8">
+        <div className="grid gap-2 h-full grid-cols-1 md:grid-cols-2 xl:grid-cols-3 xl:grid-rows-8">
           {achievements.map((achievement, index) => (
             <div
               key={index}
@@ -31,12 +31,12 @@ export const Achievements = () => {
                   : "xl:col-span-1 xl:row-span-2"
               } fade-in`}
             >
-              <div className="flex h-full w-full bg-cyber-black-400 text-white rounded-lg p-5 border-2 border-cyber-red-500">
+              <div className="flex h-full w-full bg-cyber-black-400 text-white rounded-lg p-2 sm:p-3 border-2 border-cyber-red-500">
                 <div>
-                  <h3 className="mb-2 text-2xl font-semibold">
+                  <h3 className="mb-1 text-md text-cyber-yellow-500 font-semibold">
                     {achievement.head}
                   </h3>
-                  <p>{achievement.tail}</p>
+                  <p className="text-xs sm:text-sm">{achievement.tail}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Why
--
- As a user viewing the Achievements section on mobile, it scrolling through each item should be reasonable in length
- As a user viewing the Achievements on larger screens, I should see the optimal negative space to best suite the desired layout

How
--
- Update the achievements text to hoist most important words to the title
- Update rendered classes to better accommodate various viewports 